### PR TITLE
Bug/fix unit title discussion overlap

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -433,20 +433,58 @@
 }
 
 .unit-title-header {
+  display: grid;
   width: 100%;
+  column-gap: var(--pgn-spacing-spacer-3);
+  row-gap: var(--pgn-spacing-spacer-2);
+  align-items: center;
+  grid-template-columns: 1fr;
 
   .unit-title-container {
-    flex: 1 1 0;
     min-width: 0;
+    max-width: 100%;
   }
 
   .unit-title-nav {
-    flex: 0 0 auto;
+    min-width: 0;
+    max-width: 100%;
+    justify-self: end;
+    width: 100%;
+    // Mobile-first: nav buttons sit above the title (stacked).
+    order: -1;
+
+    .top-unit-navigation {
+      width: auto;
+      max-width: 100%;
+    }
+
+    .top-unit-navigation > .d-flex.w-100 {
+      width: auto;
+      max-width: 100%;
+    }
   }
 
+  .unit-title-container h3 {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  // Switch to the side-by-side row layout only from xl up. Using a single
+  // min-width query (instead of a separate max-width-lg rule) avoids the
+  // 1200px boundary where both queries would otherwise apply at once.
   @media (--pgn-size-breakpoint-min-width-xl) {
-    .unit-title-container {
-      padding-right: var(--pgn-spacing-spacer-2);
+    grid-template-columns: minmax(0, 1fr) auto;
+
+    .unit-title-nav {
+      order: 0;
+      width: auto;
+
+      // On desktop the outline trigger renders empty, but its negative
+      // margin still pulls the discussion/notification buttons left over
+      // the title. Neutralize it inside this header only.
+      .outline-trigger-mobile {
+        margin-left: 0;
+      }
     }
   }
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,7 +5,8 @@
 @import "~@edx/frontend-component-footer/dist/footer";
 @import "~@edx/frontend-component-header/dist/index";
 @import "~@edx/brand/paragon/overrides";
-@import "~@edx/brand/paragon/learning-mfe";
+// learning-mfe.scss is not present in @openedx/brand-openedx; uncomment when custom brand is added
+//@import "~@edx/brand/paragon/learning-mfe";
 
 
 #root {

--- a/src/index.scss
+++ b/src/index.scss
@@ -432,6 +432,25 @@
   }
 }
 
+.unit-title-header {
+  width: 100%;
+
+  .unit-title-container {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .unit-title-nav {
+    flex: 0 0 auto;
+  }
+
+  @media (--pgn-size-breakpoint-min-width-xl) {
+    .unit-title-container {
+      padding-right: var(--pgn-spacing-spacer-2);
+    }
+  }
+}
+
 // This class forces any modals using 'modal-lti' as their dialogClassName to take up the whole
 // window (retaining padding around the edge).  Bootstrap modals don't have a full-screen
 // size like this.  Because of the hack below around react-focus-on's div, it would be better long-term to pull this into Paragon and perhaps call it "modal-full" or something like that.

--- a/src/plugin-slots/UnitTitleSlot/index.jsx
+++ b/src/plugin-slots/UnitTitleSlot/index.jsx
@@ -24,11 +24,11 @@ const UnitTitleSlot = ({
         renderUnitNavigation,
       }}
     >
-      <div className="unit-title-header d-flex flex-column-reverse flex-xl-row align-items-start align-items-xl-center justify-content-between gap-3">
+      <div className="unit-title-header">
         <div className="unit-title-container mb-0 mt-3 mt-xl-0">
-          <h3 className="h3 text-break mb-0">{unit.title}</h3>
+          <h3 className="h3 mb-0">{unit.title}</h3>
         </div>
-        <div className="unit-title-nav flex-shrink-0">
+        <div className="unit-title-nav">
           {renderUnitNavigation(true)}
         </div>
       </div>

--- a/src/plugin-slots/UnitTitleSlot/index.jsx
+++ b/src/plugin-slots/UnitTitleSlot/index.jsx
@@ -24,11 +24,11 @@ const UnitTitleSlot = ({
         renderUnitNavigation,
       }}
     >
-      <div className="d-flex flex-column-reverse flex-xl-row align-items-start align-items-xl-center justify-content-between">
-        <div className="mb-0 mt-3 mt-xl-0">
-          <h3 className="h3">{unit.title}</h3>
+      <div className="unit-title-header d-flex flex-column-reverse flex-xl-row align-items-start align-items-xl-center justify-content-between gap-3">
+        <div className="unit-title-container mb-0 mt-3 mt-xl-0">
+          <h3 className="h3 text-break mb-0">{unit.title}</h3>
         </div>
-        <div className="w-100">
+        <div className="unit-title-nav flex-shrink-0">
           {renderUnitNavigation(true)}
         </div>
       </div>


### PR DESCRIPTION
Long unit titles in the Learning MFE courseware header overlapped the discussion/forum and navigation buttons, and even when they didn't overlap they sat too close to the buttons. This PR makes the title wrap based on its **container width** (not its character count), keeps clear spacing from the action buttons, and behaves responsively across all breakpoints.
## Problem
In the unit header (`UnitTitleSlot`), the title `<h3>` and the nav row (discussion, notifications, prev/next) were laid out with Bootstrap flex utilities (`flex-xl-row`, `w-100`). With a long title this caused:
1. **Overlap** — the title had no `min-width: 0` / wrapping rules, so it overflowed into the buttons, especially when the discussions sidebar narrowed the content column.
2. **No spacing** — even without overlap, there was no gap between the title and the buttons.
3. The nav wrapper's `w-100` competed with the title for horizontal space.
Two additional issues surfaced while verifying with runtime layout measurements:
4. On desktop, the empty `.outline-trigger-mobile` wrapper still carried `margin-left: -2.4rem`, dragging the discussion buttons ~26px onto the title.
5. A breakpoint collision at exactly `1200px` (`min-width-xl` and `max-width-lg` both firing) collapsed the nav to `0` width.
## Changes
- **`src/plugin-slots/UnitTitleSlot/index.jsx`** — replaced the flex utility classes with semantic wrappers (`unit-title-header`, `unit-title-container`, `unit-title-nav`).
- **`src/index.scss`**
  - Introduced a CSS Grid header: `grid-template-columns: minmax(0, 1fr) auto` (≥xl) so the title is bounded by its container and wraps; single `1fr` column with the nav stacked on top below xl.
  - Added `overflow-wrap: anywhere` so long unbroken titles break instead of overflowing.
  - Added `column-gap` / `row-gap` for consistent spacing between title and buttons.
  - Neutralized the empty outline trigger's negative margin within the header on desktop.
  - Used a single `min-width: xl` query for the row layout to avoid the 1200px breakpoint collision.
  - Commented out the `@edx/brand/paragon/learning-mfe` import, which is missing from the installed `@openedx/brand-openedx` package and breaks the webpack build (approved).